### PR TITLE
Add native executor and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,201 +1,180 @@
 # Envyr
 
-Envyr is a tool to automagically package an application and run it in a sandboxed environment.
-*This project is in active development and may break.*
+Envyr automagically packages applications and runs them in sandboxed (or native) environments. It detects the language, installs dependencies, and executes projects — from local paths or git repos — without requiring any local setup.
 
-Ever wanted to run a script from a git repo without having to clone, install dependencies etc?
-Envyr does that for you. It can detect the language, install dependencies and run the project in a Sandboxed environment for you.
+> This project is in active development and may break.
 
-e.g 
 ```bash
-envyr run git@github.com:tchaudhry91/python-sample-script.git --autogen -- https://blog.tux-sudo.com > my_blog.html
+# Run a Python script straight from a git repo — no clone, no pip install, nothing
+envyr run --autogen git@github.com:tchaudhry91/python-sample-script.git -- https://blog.tux-sudo.com > my_blog.html
 ```
-This command will fetch the repo, build a sandbox (docker/podman supported at the moment), and run the script!
-Read more about the supported features below.
 
+On first run, envyr fetches the repo, detects the language, builds a sandbox, installs dependencies, and runs the script. Subsequent runs reuse the cache and are near-instant.
 
 ## Installation
-This project can be installed with Cargo. More pre-built packages will be available soon.
 
-## Usage
-Envyr has built-in intelligence to run the following types of applications at the moment:
-
-#### 1. Python Scripts
-
-Envyr will automatically detect and run your python scripts.
-
-**Detection**:
-- If the project contains a .py file, it will be detected as a python script.
-- If the project contains a requirements.txt file, it will be installed in the sandbox before execution.
-- If a requirements.txt is not found, it will attempt to produce one using [pipreqs](https://pypi.org/project/pipreqs). 
-- The entrypoint is detected via a `if __name__ == __main__` or a shebang statements. Ties are broken via a priority and can be overridden with the `-x` flag.
-
-**Example**:
-- Here is envyr running a python script from a public repository.
- ```bash
-$ envyr run --autogen git@github.com:sivel/speedtest-cli.git                    
-
-Retrieving speedtest.net configuration...
-Testing from xyz (xyz.xyz.xyz.xyz)..
-Retrieving speedtest.net server list...
-Selecting best server based on ping...
-^C
-Cancelling...
-```
-The first run will clone the repo and build the sandbox. Subsequent runs would be near instant.
-
-#### 2. Node JS Scripts
-Envyr will automatically detect and run your node.js scripts.
-
-**Detection**:
-- The project needs to contain a package.json.
-- This is used to install the dependencies and figure out the entrypoint (`main` from package.json)
-
-#### 3. Shell Scripts
-
-**Detection**:
-- Based on Shebang.
-- *Pending*: A way to detect dependencies. They can still be supplied manually while generating.
-
-
-#### 4. More to come later..
-
-### Configuration Options
-```
-$ envyr -h
-A tool to automagically create 'executable' packages for your scripts.
-
-Usage: envyr [OPTIONS] <COMMAND>
-
-Commands:
-  generate  Generate the associated meta files. Overwrites if re-run.
-  alias     Subcommands for aliases.
-  run       Run the package with the given executor.
-  help      Print this message or the help of the given subcommand(s)
-
-Options:
-  -v, --verbose      Emit Envyr logs to stdout. Useful for debugging. But may spoil pipes.
-      --root <PATH>  Override the default envyr root directory (~/.envyr)
-  -h, --help         Print help
-  -V, --version      Print version
-```
-
-**Running a Package**
-```
-$ envyr run -h
-Run the package with the given executor.
-
-Usage: envyr run [OPTIONS] <PROJECT_ROOT> [-- <ARGS>...]
-
-Arguments:
-  <PROJECT_ROOT>  The location to the project. Accepts, local filesystem path/git repos.
-  [ARGS]...       
-
-Options:
-  -s, --sub-dir <SUB_DIR>          relative sub-directory to the project_root, useful if you're working with monorepos.
-  -t, --tag <TAG>                  The tag of the package to run. Accepts git tags/commits. Defaults to latest. [default: latest]
-      --refresh                    refresh code cache before running.
-      --alias <ALIAS>              Upon successful completion, record this run command as an alias. To allow usage of `envyr run <alias>` in the future.
-  -e, --executor <EXECUTOR>        [default: docker] [possible values: docker, nix, native]
-      --autogen                    Attempt to automatically generate the package metadata before running. This overwrites existing metadata.
-      --fs-map [<FS_MAP>...]       Mount the given directory as a volume. Format: host_dir:container_dir. Allows multiples. Only applicable on Docker Executor.
-      --port-map [<PORT_MAP>...]   Map ports to host system, Format host_port:source_port. Allows multiples. Only applicable on Docker Executor.
-      --env-map [<ENV_MAP>...]     Environment variables to pass through, leave value empty to pass through the value from the current environment. Format: 'key=value' or 'key' (passwthrough). Allows multiples.
-      --timeout <TIMEOUT>          Timeout for container execution in seconds. Container process will be terminated after this duration.
-  -n, --name <NAME>                
-  -i, --interpreter <INTERPRETER>  
-  -x, --entrypoint <ENTRYPOINT>    
-  -t, --type <PTYPE>               [possible values: python, node, shell, other]
-  -h, --help                       Print help
-```
-
-Most cases should be covered by autodetection. Use the overrides if `--autogen` does not work.
-
-**Timeout Support**
-Envyr supports setting execution timeouts to automatically terminate long-running or infinite loop processes:
+### From crates.io
 
 ```bash
-# Run with a 30-second timeout
-envyr run --timeout 30 --autogen /path/to/project
-
-# Run a potentially infinite script with timeout
-envyr run --timeout 10 --autogen git@github.com:user/infinite-script.git
+cargo install envyr
 ```
 
-When a timeout occurs, the container is properly killed and an error message is displayed. Real-time output is preserved during execution.
-
-**Custom Root Directory**
-
-By default, envyr stores its data (cached repos, aliases, etc.) in `~/.envyr`. You can override this with the `--root` flag:
+### From source
 
 ```bash
-# Use a custom root directory
-envyr --root /tmp/my-envyr run --autogen /path/to/project
-
-# Useful for CI/CD or isolated environments
-envyr --root "$CI_PROJECT_DIR/.envyr" run --autogen git@github.com:user/repo.git
+git clone https://github.com/tchaudhry91/envyr.git
+cd envyr
+cargo install --path .
 ```
 
-**Generating Package Metadata in Advance**
-```
-Generate the associated meta files. Overwrites if re-run.
+### Requirements
 
-Usage: envyr generate [OPTIONS] <PROJECT_ROOT>
+- **Docker executor** (default): Docker or Podman (auto-detected)
+- **Native executor**: Python 3 (for Python projects), Node.js/npm (for Node projects)
 
-Arguments:
-  <PROJECT_ROOT>  The location to the project. Accepts, local filesystem path/git repos.
+## Quick Start
 
-Options:
-  -s, --sub-dir <SUB_DIR>          relative sub-directory to the project_root, useful if you're working with monorepos.
-  -t, --tag <TAG>                  The tag of the package to run. Accepts git tags/commits. Defaults to latest. [default: latest]
-      --refresh                    refresh code cache before running.
-  -n, --name <NAME>                
-  -i, --interpreter <INTERPRETER>  
-  -x, --entrypoint <ENTRYPOINT>    
-  -t, --type <PTYPE>               [possible values: python, node, shell, other]
-  -h, --help                       Print help
-```
+```bash
+# Run a git repo with auto-detection (Docker, the default)
+envyr run --autogen git@github.com:sivel/speedtest-cli.git
 
-The generate command is generally meant to be used by authors who can commit the `.envyr` folder generated by this command. This allows others to run this package with the optional (entrypoint/interpreter) overrides that the author desires by default.
+# Run a local project
+envyr run --autogen ./my-project
 
-**Aliasing**
-You can generate aliases for common run commands to make them more ergonomic for regular use.
-Pass the `--alias` flag to create a new alias on a successful run of a particular package.
-```
-$envyr run --alias sample --env-map=MYVAR --autogen git@github.com:tchaudhry91/python-sample-script.git -- https://blog.tux-sudo.com
+# Run natively (no container) — great for piping
+echo '{"name": "world"}' | envyr run --executor native --autogen ./my-script
 
-```
-This will store the above command as an alias called `sample` which can run as follows:
-```
-$envyr run sample
+# Pass arguments to the script
+envyr run --autogen ./my-project -- arg1 arg2
+
+# Set a timeout (seconds)
+envyr run --timeout 30 --autogen ./my-project
 ```
 
-The `args` are also stored with the alias but can be overriden if required.
-```
-$envyr run sample -- https://test.com
-```
+## Executors
 
-Aliases can be managed using the following:
-```
-$envyr alias -h        2 ↵
-Subcommands for aliases.
+### Docker (default)
 
-Usage: envyr alias <COMMAND>
+Runs the project inside a Docker (or Podman) container. This is the safest option — code runs fully sandboxed.
 
-Commands:
-  list    List all aliases.
-  delete  Delete an existing alias.
-  help    Print this message or the help of the given subcommand(s)
+```bash
+envyr run --autogen ./my-project
 
-Options:
-  -h, --help  Print help
+# With port mapping and volume mounts
+envyr run --autogen ./my-project --port-map 8080:80 --fs-map /data:/app/data
+
+# With network access and interactive mode
+envyr run --autogen --interactive --network host ./my-project
 ```
 
+### Native
 
-### Planned Features
+Runs the project directly on the host. No containerization overhead — ideal for piping JSON through scripts or quick local runs.
 
-- Only Docker/Podman are available as the sandbox enviroments at the moment. Add nix/native options too.
-- More Languages
-- Bash Script Dependency Detection.
+```bash
+# Pipe JSON through a Python script
+echo '{"input": "data"}' | envyr run --executor native --autogen ./my-script
 
-See the issue tracker/project board for more.
+# Pass environment variables
+envyr run --executor native --autogen ./my-project --env-map API_KEY=secret MY_VAR
+```
+
+For Python projects, envyr creates an isolated venv at `.envyr/venv` and installs dependencies from `requirements.txt`. For Node projects, it runs `npm install` if `node_modules` doesn't exist. Shell scripts run directly.
+
+When running git-fetched code natively, envyr prints a warning to stderr since the code is not sandboxed.
+
+## Language Support
+
+### Python
+
+- Detects `.py` files automatically
+- Installs dependencies from `requirements.txt` (or generates one via [pipreqs](https://pypi.org/project/pipreqs))
+- Finds the entrypoint via `if __name__ == "__main__"` or shebang; ties broken by priority
+- Override with `-x <entrypoint>`
+
+### Node.js
+
+- Requires `package.json` (used for dependency installation and entrypoint detection via `main` field)
+- Dependencies installed via `npm install`
+
+### Shell
+
+- Detected via shebang (`#!/bin/bash`, etc.)
+- OS-level dependencies can be specified manually during generation
+
+## Aliases
+
+Save frequently used commands as aliases for quick re-use:
+
+```bash
+# Create an alias on successful run
+envyr run --alias sample --autogen git@github.com:user/repo.git -- default-arg
+
+# Run it later
+envyr run sample
+
+# Override args
+envyr run sample -- different-arg
+
+# List and manage aliases
+envyr alias list
+envyr alias delete sample
+```
+
+## Generating Metadata
+
+The `generate` command creates `.envyr/meta.json` (and a Dockerfile) for a project. This is useful for project authors who want to commit the `.envyr` folder so others can run the project without `--autogen`:
+
+```bash
+envyr generate ./my-project
+
+# With overrides
+envyr generate ./my-project --entrypoint app.py --type python
+```
+
+When using `--autogen` with `run`, this step happens automatically.
+
+## Override Options
+
+If auto-detection doesn't work, override manually:
+
+| Flag | Description |
+|------|-------------|
+| `-n, --name` | Project name |
+| `-i, --interpreter` | Interpreter path (e.g. `/usr/bin/env python`) |
+| `-x, --entrypoint` | Script entrypoint (e.g. `main.py`) |
+| `-t, --type` | Language type: `python`, `node`, `shell`, `other` |
+
+## Environment Variables
+
+Pass environment variables to the executed script:
+
+```bash
+# Explicit key=value
+envyr run --autogen ./my-project --env-map API_KEY=secret
+
+# Passthrough from current shell
+envyr run --autogen ./my-project --env-map HOME USER
+
+# Works with both executors
+envyr run --executor native --autogen ./my-project --env-map DB_URL=postgres://localhost/mydb
+```
+
+## Custom Root Directory
+
+By default, envyr stores cached repos and aliases in `~/.envyr`. Override with `--root`:
+
+```bash
+envyr --root /tmp/my-envyr run --autogen ./my-project
+```
+
+## Planned Features
+
+- More language support
+- Bash script dependency detection
+
+See the [issue tracker](https://github.com/tchaudhry91/envyr/issues) for more.
+
+## License
+
+[Apache-2.0](LICENSE)

--- a/src/envyr/mod.rs
+++ b/src/envyr/mod.rs
@@ -1,5 +1,6 @@
 pub mod docker;
 pub mod meta;
+pub mod native;
 pub mod package;
 pub mod templates;
 pub mod utils;

--- a/src/envyr/native.rs
+++ b/src/envyr/native.rs
@@ -1,0 +1,332 @@
+use std::env;
+use std::path::Path;
+use std::time::Instant;
+
+use anyhow::Result;
+use log::debug;
+use subprocess::{Popen, PopenConfig};
+
+use super::package::{PType, Pack};
+
+pub struct NativeRunOpts {
+    pub env_map: Vec<String>,
+    pub timeout: Option<u32>,
+    pub args: Vec<String>,
+}
+
+pub fn run(
+    project_root: &Path,
+    envyr_root: &Path,
+    pack: &Pack,
+    opts: NativeRunOpts,
+    start: Instant,
+) -> Result<()> {
+    // Warn if running a remote (git-fetched) source without sandboxing
+    if project_root.starts_with(envyr_root) {
+        eprintln!(
+            "Warning: Native executor runs code without sandboxing. Ensure you trust this source."
+        );
+    }
+
+    // Install dependencies based on project type
+    install_deps(project_root, &pack.ptype)?;
+
+    // Resolve interpreter (Python uses venv python)
+    let interpreter = resolve_interpreter(project_root, pack);
+
+    // Build command
+    let entrypoint_str = pack
+        .entrypoint
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("Entrypoint path contains invalid UTF-8"))?;
+
+    // Split interpreter on whitespace (e.g. "/usr/bin/env python" -> ["/usr/bin/env", "python"])
+    let mut cmd_parts: Vec<String> = interpreter
+        .split_whitespace()
+        .map(|s| s.to_string())
+        .collect();
+    cmd_parts.push(entrypoint_str.to_string());
+    cmd_parts.extend(opts.args.iter().cloned());
+
+    let cmd_strs: Vec<&str> = cmd_parts.iter().map(|s| s.as_str()).collect();
+
+    // Resolve environment variables
+    let env_vars = resolve_env_map(&opts.env_map);
+
+    let popen_config = PopenConfig {
+        cwd: Some(project_root.as_os_str().to_owned()),
+        env: Some(build_env_with_extras(&env_vars)),
+        ..Default::default()
+    };
+
+    // Inherit stdin/stdout/stderr (default PopenConfig behavior)
+    debug!("Running command: {}", cmd_parts.join(" "));
+    debug!("Time Elapsed in Setup: {:?}", start.elapsed());
+
+    let mut p = Popen::create(&cmd_strs, popen_config)?;
+
+    let status = if let Some(timeout_secs) = opts.timeout {
+        debug!("Running with timeout: {} seconds", timeout_secs);
+        match p.wait_timeout(std::time::Duration::from_secs(timeout_secs as u64))? {
+            Some(status) => status,
+            None => {
+                debug!(
+                    "Process execution timed out after {} seconds",
+                    timeout_secs
+                );
+                p.terminate()?;
+                return Err(anyhow::anyhow!(
+                    "Process execution timed out after {} seconds",
+                    timeout_secs
+                ));
+            }
+        }
+    } else {
+        p.wait()?
+    };
+
+    if !status.success() {
+        return Err(anyhow::anyhow!(
+            "Process exited with non-zero status: {:?}",
+            status
+        ));
+    }
+    Ok(())
+}
+
+fn install_deps(project_root: &Path, ptype: &PType) -> Result<()> {
+    match ptype {
+        PType::Python => install_python_deps(project_root),
+        PType::Node => install_node_deps(project_root),
+        PType::Shell | PType::Other => Ok(()),
+    }
+}
+
+fn install_python_deps(project_root: &Path) -> Result<()> {
+    let venv_path = project_root.join(".envyr").join("venv");
+    if !venv_path.exists() {
+        debug!("Creating Python venv at {:?}", venv_path);
+        let status = std::process::Command::new("python3")
+            .args(["-m", "venv"])
+            .arg(&venv_path)
+            .status()?;
+        if !status.success() {
+            return Err(anyhow::anyhow!("Failed to create Python venv"));
+        }
+    }
+
+    let requirements = project_root.join("requirements.txt");
+    if requirements.exists() {
+        let pip_path = venv_path.join("bin").join("pip");
+        debug!("Installing Python dependencies from requirements.txt");
+        let status = std::process::Command::new(pip_path)
+            .args(["install", "-r"])
+            .arg(&requirements)
+            .current_dir(project_root)
+            .status()?;
+        if !status.success() {
+            return Err(anyhow::anyhow!(
+                "Failed to install Python dependencies from requirements.txt"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn install_node_deps(project_root: &Path) -> Result<()> {
+    let package_json = project_root.join("package.json");
+    let node_modules = project_root.join("node_modules");
+    if package_json.exists() && !node_modules.exists() {
+        debug!("Running npm install");
+        let status = std::process::Command::new("npm")
+            .arg("install")
+            .current_dir(project_root)
+            .status()?;
+        if !status.success() {
+            return Err(anyhow::anyhow!("Failed to run npm install"));
+        }
+    }
+    Ok(())
+}
+
+fn resolve_interpreter(project_root: &Path, pack: &Pack) -> String {
+    match pack.ptype {
+        PType::Python => {
+            let venv_python = project_root
+                .join(".envyr")
+                .join("venv")
+                .join("bin")
+                .join("python");
+            venv_python.to_string_lossy().to_string()
+        }
+        _ => pack.interpreter.clone(),
+    }
+}
+
+fn resolve_env_map(env_map: &[String]) -> Vec<(String, String)> {
+    env_map
+        .iter()
+        .map(|x| {
+            if let Some((key, value)) = x.split_once('=') {
+                (key.to_string(), value.to_string())
+            } else {
+                let resolved = env::var(x).unwrap_or_default();
+                (x.clone(), resolved)
+            }
+        })
+        .collect()
+}
+
+fn build_env_with_extras(extras: &[(String, String)]) -> Vec<(std::ffi::OsString, std::ffi::OsString)> {
+    let mut env: Vec<(std::ffi::OsString, std::ffi::OsString)> = env::vars_os().collect();
+    for (key, value) in extras {
+        // Remove existing entry if present, then add
+        env.retain(|(k, _)| k != key.as_str());
+        env.push((key.into(), value.into()));
+    }
+    env
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn create_test_pack(ptype: PType, interpreter: &str, entrypoint: &str) -> Pack {
+        Pack {
+            name: "test-project".to_string(),
+            interpreter: interpreter.to_string(),
+            ptype,
+            deps: vec![],
+            entrypoint: PathBuf::from(entrypoint),
+        }
+    }
+
+    #[test]
+    fn test_resolve_interpreter_python() {
+        let temp_dir = TempDir::new().unwrap();
+        let pack = create_test_pack(PType::Python, "/usr/bin/env python", "main.py");
+        let interpreter = resolve_interpreter(temp_dir.path(), &pack);
+        let expected = temp_dir
+            .path()
+            .join(".envyr")
+            .join("venv")
+            .join("bin")
+            .join("python");
+        assert_eq!(interpreter, expected.to_string_lossy().to_string());
+    }
+
+    #[test]
+    fn test_resolve_interpreter_node() {
+        let temp_dir = TempDir::new().unwrap();
+        let pack = create_test_pack(PType::Node, "/usr/bin/env node", "index.js");
+        let interpreter = resolve_interpreter(temp_dir.path(), &pack);
+        assert_eq!(interpreter, "/usr/bin/env node");
+    }
+
+    #[test]
+    fn test_resolve_interpreter_shell() {
+        let temp_dir = TempDir::new().unwrap();
+        let pack = create_test_pack(PType::Shell, "/bin/bash", "script.sh");
+        let interpreter = resolve_interpreter(temp_dir.path(), &pack);
+        assert_eq!(interpreter, "/bin/bash");
+    }
+
+    #[test]
+    fn test_resolve_interpreter_other() {
+        let temp_dir = TempDir::new().unwrap();
+        let pack = create_test_pack(PType::Other, "/usr/bin/custom", "app");
+        let interpreter = resolve_interpreter(temp_dir.path(), &pack);
+        assert_eq!(interpreter, "/usr/bin/custom");
+    }
+
+    #[test]
+    fn test_env_map_resolution_key_value() {
+        let env_map = vec!["KEY=value".to_string(), "FOO=bar".to_string()];
+        let resolved = resolve_env_map(&env_map);
+        assert_eq!(resolved.len(), 2);
+        assert_eq!(resolved[0], ("KEY".to_string(), "value".to_string()));
+        assert_eq!(resolved[1], ("FOO".to_string(), "bar".to_string()));
+    }
+
+    #[test]
+    fn test_env_map_resolution_passthrough() {
+        env::set_var("ENVYR_TEST_VAR", "test_value");
+        let env_map = vec!["ENVYR_TEST_VAR".to_string()];
+        let resolved = resolve_env_map(&env_map);
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(
+            resolved[0],
+            ("ENVYR_TEST_VAR".to_string(), "test_value".to_string())
+        );
+        env::remove_var("ENVYR_TEST_VAR");
+    }
+
+    #[test]
+    fn test_env_map_resolution_missing_passthrough() {
+        env::remove_var("ENVYR_NONEXISTENT_VAR");
+        let env_map = vec!["ENVYR_NONEXISTENT_VAR".to_string()];
+        let resolved = resolve_env_map(&env_map);
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(
+            resolved[0],
+            ("ENVYR_NONEXISTENT_VAR".to_string(), String::new())
+        );
+    }
+
+    #[test]
+    fn test_is_remote_source() {
+        let envyr_root = Path::new("/home/user/.envyr");
+        let remote_path = Path::new("/home/user/.envyr/cache/some-repo");
+        let local_path = Path::new("/home/user/projects/my-project");
+
+        assert!(remote_path.starts_with(envyr_root));
+        assert!(!local_path.starts_with(envyr_root));
+    }
+
+    #[test]
+    fn test_install_deps_shell_noop() {
+        let temp_dir = TempDir::new().unwrap();
+        // Should succeed without doing anything
+        install_deps(temp_dir.path(), &PType::Shell).unwrap();
+        install_deps(temp_dir.path(), &PType::Other).unwrap();
+    }
+
+    #[test]
+    fn test_install_python_deps_creates_venv() {
+        let temp_dir = TempDir::new().unwrap();
+        let envyr_dir = temp_dir.path().join(".envyr");
+        fs::create_dir(&envyr_dir).unwrap();
+
+        // This test requires python3 to be available
+        let result = install_python_deps(temp_dir.path());
+        if result.is_ok() {
+            let venv_path = envyr_dir.join("venv");
+            assert!(venv_path.exists());
+            assert!(venv_path.join("bin").join("python").exists());
+        }
+        // If python3 is not available, the test gracefully skips
+    }
+
+    #[test]
+    fn test_install_node_deps_skips_without_package_json() {
+        let temp_dir = TempDir::new().unwrap();
+        // No package.json, should be a no-op
+        install_node_deps(temp_dir.path()).unwrap();
+        assert!(!temp_dir.path().join("node_modules").exists());
+    }
+
+    #[test]
+    fn test_build_env_with_extras() {
+        let extras = vec![
+            ("MY_KEY".to_string(), "my_value".to_string()),
+        ];
+        let env = build_env_with_extras(&extras);
+        let found = env.iter().any(|(k, v)| {
+            k == "MY_KEY" && v == "my_value"
+        });
+        assert!(found);
+    }
+}


### PR DESCRIPTION
Implement a native executor that runs projects directly on the host without Docker containerization. Ideal for piping JSON through scripts where container overhead is unnecessary.

- Python: creates isolated venv, installs from requirements.txt
- Node: runs npm install if node_modules missing
- Shell: executes directly
- Warns on stderr when running git-fetched code without sandboxing
- Supports timeout and environment variable passthrough

Make Dockerfile generation conditional (skipped for native executor). Rewrite README with accurate docs, install instructions, and examples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native execution option alongside Docker, enabling projects to run without containerization.
  * Native executor handles automatic dependency installation (Python/Node) and environment variable configuration.
  * Added timeout support for controlled execution workflows.

* **Documentation**
  * Restructured README with expanded Quick Start guide, executor selection overview, and environment variable documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->